### PR TITLE
Stop touch events from expiring after a timeout in favour of clearing them on mouse event match

### DIFF
--- a/src/event/Tracker.js
+++ b/src/event/Tracker.js
@@ -41,17 +41,6 @@ define(function(require) {
     var TARGET_LOCKS = {};
 
     /**
-     * Max time between touch and simulated mouse event (3 seconds)
-     *
-     * We only use this to expire a touch event - after 3 seconds,
-     * no longer use this event when detecting simulated events.
-     *
-     * @type Number
-     * @static
-     */
-    var DELTA_TIME = 3000;
-
-    /**
      * Default capture event data
      *
      * @type Object
@@ -212,14 +201,6 @@ define(function(require) {
                 }
 
                 pointer = previousEvent[pointerId];
-
-                // If too much time has passed since the last touch
-                // event, remove it so we no longer test against it.
-                if (Math.abs(now - pointer.timeStamp) > DELTA_TIME) {
-                    LAST_EVENTS[eventName][pointerId] = null;
-                    continue;
-                }
-
                 if (
                     pointer.target === target
                     && pointer.x === event.clientX

--- a/src/event/Tracker.js
+++ b/src/event/Tracker.js
@@ -206,6 +206,7 @@ define(function(require) {
                     && pointer.x === event.clientX
                     && pointer.y === event.clientY
                 ) {
+                    LAST_EVENTS[eventName][pointerId] = null;
                     return true;
                 }
             }


### PR DESCRIPTION
Since according to the W3C standard simulated mouse events are sent only after the touch gesture has finished (after the `touchend` event), touch events shouldn't expire after a set amount of time (maybe after a set amount of time after the `touchend` or `touchcancel` event fires for it's `touchid`), but only after they get matched with a simulated mouse event.
This pull request fixes that.